### PR TITLE
Remove unused `jest-config` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "ansi-escapes": "^3.1.0",
     "chalk": "^2.4.1",
     "eslint": "^4.5.0",
-    "jest-config": "^23.0.1",
     "prompts": "^0.1.8"
   },
   "devDependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,6 @@
 const chalk = require('chalk');
 const prompts = require('prompts');
 const ansiEscapes = require('ansi-escapes');
-const { readConfig } = require('jest-config');
 const path = require('path');
 
 class JestPluginProjects {


### PR DESCRIPTION
Seems like it was imported, but not used 👍 Lock file does not seem to have updated though.