### PR TITLE
Added custom prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,27 @@ Or in `jest.config.js`
 
 ```js
 module.exports = {
-  watchPlugins: ['jest-watch-select-projects']
+  watchPlugins: ['jest-watch-select-projects'],
+};
+```
+
+### Configuring your key and prompt name
+
+```js
+module.exports = {
+  watchPlugins: [
+    [
+      'jest-watch-select-projects',
+      {
+        key: 'X',
+        // function or string
+        prompt() {
+          const activeProjectsText = this._getActiveProjectsText();
+          return 'do something with my custom prompt';
+        },
+      },
+    ],
+  ],
 };
 ```
 
@@ -56,5 +76,3 @@ yarn jest --watch
 **Why is this running all of my projects?**
 
 Make certain that you're using the SPACE key to toggle the selected state of projects and the ENTER key to confirm your settings.
-
-

--- a/src/index.js
+++ b/src/index.js
@@ -5,9 +5,19 @@ const { readConfig } = require('jest-config');
 const path = require('path');
 
 class JestPluginProjects {
-  constructor() {
+  constructor({ config }) {
     this._activeProjects = {};
     this._projectNames = [];
+    this._usageInfo = {
+      key: config.key || 'P',
+      prompt:
+        config.prompt ||
+        function() {
+          return `select projects ${chalk.italic(
+            this._getActiveProjectsText(),
+          )}`;
+        },
+    };
   }
 
   apply(jestHook) {
@@ -114,9 +124,14 @@ Add a \`displayName\` to at least one of them to prevent name collision.
   }
 
   getUsageInfo() {
+    const { key, prompt } = this._usageInfo;
+
+    const evaluatedPrompt =
+      typeof prompt === 'function' ? prompt.call(this) : prompt;
+
     return {
-      key: 'P',
-      prompt: `select projects ${chalk.italic(this._getActiveProjectsText())}`,
+      key,
+      prompt: evaluatedPrompt,
     };
   }
 }


### PR DESCRIPTION
## Why

I want to use a custom key and prompt in [`jest-expo`](https://github.com/expo/expo/issues/5278) based on @SimenB' suggestion. Specifically to rename projects to platforms or something.

## How

Added this: [configuring your key and prompt name](https://github.com/jest-community/jest-watch-typeahead#configuring-your-key-and-prompt-name)

## Test Plan

Copied the code into my local project and ran it:

- with method for prompt
- with string for prompt
- without custom options